### PR TITLE
Reduced depth of jobs query for quicker API calls

### DIFF
--- a/src/pyjen/jenkins.py
+++ b/src/pyjen/jenkins.py
@@ -170,7 +170,7 @@ class Jenkins(object):
 
         :rtype:  :class:`list` of :class:`~.job.Job` objects
         """
-        data = self._api.get_api_data(query_params="depth=2")
+        data = self._api.get_api_data(query_params="depth=0")
 
         retval = list()
         for j in data['jobs']:

--- a/src/pyjen/plugins/multibranch_pipeline.py
+++ b/src/pyjen/plugins/multibranch_pipeline.py
@@ -11,7 +11,7 @@ class MultibranchPipelineJob(Job):
 
         :rtype: :class:`list` of :class:`~.pipelinejob.PipelineJob`
         """
-        data = self._api.get_api_data(query_params="depth=2")
+        data = self._api.get_api_data(query_params="depth=0")
 
         retval = list()
         for j in data["jobs"]:

--- a/src/pyjen/view.py
+++ b/src/pyjen/view.py
@@ -65,7 +65,7 @@ class View(object):
         :returns: list of 0 or more jobs that are included in this view
         :rtype:  :class:`list` of :class:`~.job.Job` objects
         """
-        data = self._api.get_api_data(query_params="depth=2")
+        data = self._api.get_api_data(query_params="depth=0")
 
         view_jobs = data['jobs']
 


### PR DESCRIPTION
Reduced depth of API jobs retrievals to decrease time spent fetching data.

When reduced from 2 to 0, all present tests still pass. 