### PR TITLE
Add URL property to the Build class

### DIFF
--- a/src/pyjen/build.py
+++ b/src/pyjen/build.py
@@ -48,6 +48,15 @@ class Build(object):
         return hash(self.uid)
 
     @property
+    def url(self):
+        """Gets the URL of this build
+
+        :returns: full url to this build
+        :rtype: :class:`str`
+        """
+        return self._api.url
+
+    @property
     def number(self):
         """Gets the sequence number of this build
 

--- a/src/pyjen/version.py
+++ b/src/pyjen/version.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-docstring
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
In the 1.0.0 update all of the public properties in the main API class are no longer exposed due to this change: https://github.com/TheFriendlyCoder/pyjen/commit/d0481aece27b123e0a87ac194c552c4596f144cf#diff-cb4c15c1a34551ed5bcbe07ec55b16af
For now we just need the URL in the build class so this is not a full fix.